### PR TITLE
added missing config role

### DIFF
--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - prometheus-prometheus.yaml
   - prometheus-service.yaml
   - prometheus-rules.yaml
+  - prometheus-roleConfig.yaml 
   - prometheus-roleBindingConfig.yaml
   - prometheus-roleBindingSpecificNamespaces.yaml
   - prometheus-roleSpecificNamespaces.yaml

--- a/base/prometheus/prometheus-roleConfig.yaml
+++ b/base/prometheus/prometheus-roleConfig.yaml
@@ -1,0 +1,13 @@
+  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s-config
+  namespace: monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get


### PR DESCRIPTION
Looking into the roles, I found a headless roleBinding (no role) so looked into kube-prometheus and role was there, added the role here too.